### PR TITLE
Update meta.yaml with build/number 1

### DIFF
--- a/recipes/jvarkit/meta.yaml
+++ b/recipes/jvarkit/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin=None) }}
     # it's date based (yyyy.mm.dd) there's no real semantic pinning, and breaking changes happen (e.g.: tools / libraries being removed)


### PR DESCRIPTION
I'm trying to fix https://github.com/galaxyproject/galaxy/issues/18761 

Build number should be increased to generated the proper singularity image on the galaxy side (?)